### PR TITLE
Fix: Hide tokenizationMethod from public API

### DIFF
--- a/apps/capi/src/capi_real_handler.erl
+++ b/apps/capi/src/capi_real_handler.erl
@@ -2019,8 +2019,8 @@ decode_bank_card(#domain_BankCard{
     'token_provider'      = TokenProvider,
     'issuer_country'      = IssuerCountry,
     'bank_name'           = BankName,
-    'metadata'            = Metadata,
-    'tokenization_method' = TokenizationMethod
+    'metadata'            = Metadata
+    % 'tokenization_method' = TokenizationMethod
 }) ->
     capi_utils:map_to_base64url(genlib_map:compact(#{
         <<"type">>                =>  <<"bank_card">>,
@@ -2031,8 +2031,9 @@ decode_bank_card(#domain_BankCard{
         <<"token_provider">>      => TokenProvider,
         <<"issuer_country">>      => IssuerCountry,
         <<"bank_name"     >>      => BankName,
-        <<"metadata"      >>      => decode_bank_card_metadata(Metadata),
-        <<"tokenization_method">> => TokenizationMethod
+        <<"metadata"      >>      => decode_bank_card_metadata(Metadata)
+        % TODO: Uncomment or delete this when we negotiate deploying non-breaking changes
+        % <<"tokenization_method">> => TokenizationMethod
     })).
 
 decode_bank_card_metadata(undefined) ->
@@ -2847,8 +2848,9 @@ decode_bank_card_details(BankCard, V) ->
         <<"bin">>            => Bin,
         <<"cardNumberMask">> => decode_masked_pan(Bin, LastDigits),
         <<"paymentSystem" >> => genlib:to_binary(BankCard#domain_BankCard.payment_system),
-        <<"tokenProvider" >> => decode_token_provider(BankCard#domain_BankCard.token_provider),
-        <<"tokenizationMethod">> => genlib:to_binary(BankCard#domain_BankCard.tokenization_method)
+        <<"tokenProvider" >> => decode_token_provider(BankCard#domain_BankCard.token_provider)
+        % TODO: Uncomment or delete this when we negotiate deploying non-breaking changes
+        % <<"tokenizationMethod">> => genlib:to_binary(BankCard#domain_BankCard.tokenization_method)
     }).
 
 decode_bank_card_bin(<<>>) ->


### PR DESCRIPTION
Аналог https://github.com/rbkmoney/erlang_capi_v2/pull/488